### PR TITLE
Beejones/add additional reference to key reference to point to different name for remote signing

### DIFF
--- a/libs/keyStore/lib/KeyReference.ts
+++ b/libs/keyStore/lib/KeyReference.ts
@@ -10,10 +10,11 @@ import { CryptoKey } from 'webcrypto-core'
 export default class KeyReference {
   /**
    * Create an instance of <see @class KeyReference>
-   * @param keyReference Name of the key
+   * @param keyReference Name of the key in DID document
    * @param extractable True if the key is extractable
+   * @param remoteKeyReference Name of the key in a remote server such as key vault. Can be used when difference from DID document
    * @param cryptoKey Reference to a key in an external system
    */
-  constructor(public keyReference: string, public type: string = 'secret', public cryptoKey?: CryptoKey) {
+  constructor(public keyReference: string, public type: string = 'secret', public remoteKeyReference?: string, public cryptoKey?: CryptoKey) {
   }
 }

--- a/libs/keyStore/package.json
+++ b/libs/keyStore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-keystore",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "description": "Package for managing keys in a key store.",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "typescript": "3.9.2"
   },
   "dependencies": {
-    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.5",
     "@types/node": "12.12.16",
     "base64url": "^3.0.1",
     "clone": "^2.1.2",

--- a/libs/keyStore/tests/KeyReference.spec.ts
+++ b/libs/keyStore/tests/KeyReference.spec.ts
@@ -7,15 +7,24 @@ describe('KeyReference', () =>{
         expect(reference.type).toEqual('secret');
         expect(reference.keyReference).toEqual('key');
         expect(reference.cryptoKey).toBeUndefined();
+        expect(reference.remoteKeyReference).toBeUndefined();
 
         reference = new KeyReference('key', 'secret');
         expect(reference.type).toEqual('secret');
         expect(reference.keyReference).toEqual('key');
         expect(reference.cryptoKey).toBeUndefined();
-
-        reference = new KeyReference('key', 'secret', new CryptoKey());
+        expect(reference.remoteKeyReference).toBeUndefined();
+        
+        reference = new KeyReference('key', 'secret', 'remote');
         expect(reference.type).toEqual('secret');
         expect(reference.keyReference).toEqual('key');
+        expect(reference.remoteKeyReference).toEqual('remote');
+        expect(reference.cryptoKey).toBeUndefined();
+        
+        reference = new KeyReference('key', 'secret', 'remote', new CryptoKey());
+        expect(reference.type).toEqual('secret');
+        expect(reference.keyReference).toEqual('key');
+        expect(reference.remoteKeyReference).toEqual('remote');
         expect(reference.cryptoKey).toBeDefined();
     });
 });

--- a/libs/keyStore/tests/KeyStoreInMemory.spec.ts
+++ b/libs/keyStore/tests/KeyStoreInMemory.spec.ts
@@ -47,7 +47,7 @@ describe('KeyStoreInMemory', () => {
     let list = await keyStore.list();
 
     // tslint:disable-next-line: no-backbone-get-set-outside-model
-    expect(list['1'].kids.length).toEqual(3);
+    expect(list['1'].kids.length).toEqual(2);
     expect(list['1'].kty).toEqual(KeyType.RSA);
     expect(list['1'].kids[0]).toEqual('kid1');
     expect(list['1'].kids[1]).toEqual('kid2');

--- a/libs/keyStore/tests/KeyStoreInMemory.spec.ts
+++ b/libs/keyStore/tests/KeyStoreInMemory.spec.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RsaPublicKey, KeyType, PublicKey, KeyContainer, OctKey, RsaPrivateKey } from 'verifiablecredentials-crypto-sdk-typescript-keys';
+import { RsaPublicKey, KeyType, PublicKey, KeyContainer, OctKey, RsaPrivateKey, OkpPublicKey, EcPublicKey } from 'verifiablecredentials-crypto-sdk-typescript-keys';
 import base64url from 'base64url';
 import { KeyStoreInMemory, KeyStoreOptions, KeyReference } from '../lib/index';
 
@@ -25,27 +25,42 @@ describe('KeyStoreInMemory', () => {
       n: 'xxxxxxxxx',
       alg: 'none'
     };
-    const key3: RsaPublicKey = {
-      kty: KeyType.RSA,
+    const key3: OkpPublicKey = {
+      kty: KeyType.OKP,
       kid: 'kid3',
-      e: 'AAEE',
-      n: 'xxxxxxxxx',
-      alg: 'none'
+      crv: 'ed25519',
+      x: 'AAEE',
+      alg: 'EdDSA'
+    };
+    const key4: EcPublicKey = {
+      kty: KeyType.EC,
+      kid: 'kid4',
+      crv: 'secp256k1',
+      x: 'AAEE',
+      y: 'AAEE',
+      alg: 'ECDSA'
     };
     await keyStore.save(new KeyReference('1'), key1);
     await keyStore.save(new KeyReference('1'), key2);
     await keyStore.save(new KeyReference('2'), <PublicKey>key3);
+    await keyStore.save(new KeyReference('3'), <PublicKey>key4);
     let list = await keyStore.list();
 
     // tslint:disable-next-line: no-backbone-get-set-outside-model
-    expect(list['1'].kids.length).toEqual(2);
+    expect(list['1'].kids.length).toEqual(3);
     expect(list['1'].kty).toEqual(KeyType.RSA);
     expect(list['1'].kids[0]).toEqual('kid1');
     expect(list['1'].kids[1]).toEqual('kid2');
     // tslint:disable-next-line: no-backbone-get-set-outside-model
     expect(list['2'].kids.length).toEqual(1);
-    expect(list['2'].kty).toEqual(KeyType.RSA);
+    expect(list['2'].kty).toEqual(KeyType.OKP);
     expect(list['2'].kids[0]).toEqual('kid3');
+    let key: any = await keyStore.get(new KeyReference('2'), { publicKeyOnly: true });
+    expect(key.keys[0].kty).toEqual(KeyType.OKP);
+    expect(key.keys[0].kid).toEqual('kid3');
+    key = await keyStore.get(new KeyReference('3'), { publicKeyOnly: true });
+    expect(key.keys[0].kty).toEqual(KeyType.EC);
+    expect(key.keys[0].kid).toEqual('kid4');
 
     const rsaKey: any = {
       kty: KeyType.RSA,
@@ -60,7 +75,7 @@ describe('KeyStoreInMemory', () => {
       alg: 'none'
     };
     await keyStore.save(new KeyReference('rsaKey'), rsaKey);
-    let key: any = await keyStore.get(new KeyReference('rsaKey'), { publicKeyOnly: true });
+    key = await keyStore.get(new KeyReference('rsaKey'), { publicKeyOnly: true });
     expect(key.d).toBeUndefined();
     expect(key.p).toBeUndefined();
     expect(key.q).toBeUndefined();

--- a/libs/keys/package.json
+++ b/libs/keys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-keys",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "description": "Package for managing keys in the DID space.",
   "repository": {
     "type": "git",

--- a/libs/plugin-cryptofactory-suites/package.json
+++ b/libs/plugin-cryptofactory-suites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-plugin-cryptofactory-suites",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "description": "Package crypto factory suites.",
   "repository": {
     "type": "git",
@@ -36,9 +36,9 @@
     "typescript": "3.9.2"
   },
   "dependencies": {
-    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-elliptic": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-elliptic": "1.1.11-preview.5",
     "base64url": "^3.0.1",
     "clone": "2.1.2",
     "node-jose": "1.0.0",

--- a/libs/plugin-elliptic/package.json
+++ b/libs/plugin-elliptic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-plugin-elliptic",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript.git"
@@ -29,7 +29,7 @@
     "elliptic": "6.5.3",
     "minimalistic-crypto-utils": "1.0.1",
     "sha.js": "^2.4.11",
-    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.5",
     "webcrypto-core": "1.1.1"
   },
   "devDependencies": {

--- a/libs/plugin-factory/package.json
+++ b/libs/plugin-factory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-plugin-factory",
   "description": "Factory Package for crypto plugins.",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript.git"
@@ -37,10 +37,10 @@
   },
   "dependencies": {
     "@azure/identity": "1.0.0",
-    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-cryptofactory-suites": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-keyvault": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-cryptofactory-suites": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-keyvault": "1.1.11-preview.5",
     "@types/node": "12.12.16",
     "webcrypto-core": "1.1.1"
   },

--- a/libs/plugin-keyvault/package.json
+++ b/libs/plugin-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-plugin-keyvault",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript.git"
@@ -47,10 +47,10 @@
     "@azure/identity": "1.0.0",
     "@azure/keyvault-keys": "4.0.2",
     "@azure/keyvault-secrets": "4.0.2",
-    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-elliptic": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-elliptic": "1.1.11-preview.5",
     "base64url": "3.0.1",
     "clone": "2.1.2",
     "webcrypto-core": "1.1.1"

--- a/libs/plugin-keyvault/src/plugin/KeyVaultProvider.ts
+++ b/libs/plugin-keyvault/src/plugin/KeyVaultProvider.ts
@@ -34,7 +34,7 @@ export default abstract class KeyVaultProvider extends ProviderCrypto {
   async generate(kty: KeyType, algorithm: Algorithm, _extractable: boolean, keyUsages: KeyUsage[], options?: IKeyGenerationOptions): Promise<[string, any]> {
     let name: string = this.generateKeyName(algorithm, keyUsages, kty);
     if (options && options.keyReference) {
-      name = options.keyReference.keyReference;
+      name = options.keyReference.remoteKeyReference || options.keyReference.keyReference;
     }
 
     const client = <KeyClient>(<KeyStoreKeyVault>this.keyStore).getKeyStoreClient(KeyStoreKeyVault.KEYS);

--- a/libs/plugin-keyvault/tests/Credentials.ts
+++ b/libs/plugin-keyvault/tests/Credentials.ts
@@ -2,10 +2,10 @@
  * Class to model your Key Vault credentials
  */
 
-export default class Credentials {
-        public static tenantGuid =  '72f988bf-86f1-41af-91ab-2d7cd011db47';
-        public static clientId = '7fa8fc75-9416-4f21-8b50-0a28e88e8b98';
-        public static clientSecret = 'qG7u3c4mlCq+tsSXNtL?oTgPO@2uC*oc';
-        public static vaultUri = 'https://did-keyvault-testing.vault.azure.net/'
-    }
-    
+export default class Credentials {
+    public static tenantGuid = 'Your tenant GUID here';
+    public static clientId = 'Your key vault client id here';
+    public static clientSecret = 'Your key vault client secret here';
+    public static vaultUri = 'Your key vault uri here'
+}
+

--- a/libs/plugin-keyvault/tests/KeyVaultPlugin.spec.ts
+++ b/libs/plugin-keyvault/tests/KeyVaultPlugin.spec.ts
@@ -8,7 +8,7 @@ import KeyVaultEcdsaProvider from '../src/plugin/KeyVaultEcdsaProvider';
 import KeyVaultRsaOaepProvider from '../src/plugin/KeyVaultRsaOaepProvider';
 import { KeyStoreOptions, KeyStoreInMemory, KeyReference } from 'verifiablecredentials-crypto-sdk-typescript-keystore';
 import { KeyClient } from '@azure/keyvault-keys';
-import { Subtle, CryptoFactoryScope } from 'verifiablecredentials-crypto-sdk-typescript-plugin';
+import { Subtle, CryptoFactoryScope, IKeyGenerationOptions } from 'verifiablecredentials-crypto-sdk-typescript-plugin';
 import Credentials from './Credentials';
 import { KeyVaultProvider, CryptoFactoryKeyVault } from '../src';
 const clone = require('clone');
@@ -21,7 +21,7 @@ const vaultUri = Credentials.vaultUri;
 const keyVaultEnable = vaultUri.startsWith('https://');
 
 const subtle = new Subtle();
-// const random = (length: number) => Math.random().toString(36).substring(length);
+const random = (length: number) => Math.random().toString(36).substring(2, length + 2);
 const logging = require('adal-node').Logging;
 logging.setLoggingOptions({
   log: (_level: any, _message: any, _error: any) => {
@@ -59,8 +59,51 @@ describe('KeyVaultPlugin', () => {
       expect((<any>result.publicKey).algorithm.namedCurve).toEqual('K-256');
       expect(result.publicKey.algorithm.name).toEqual('ECDSA');
       expect((<any>result.publicKey.algorithm).kid.startsWith('https')).toBeTruthy();
+      expect((<any>result.publicKey.algorithm).kid.includes(name)).toBeTruthy();
     } finally {
       await (<KeyClient>keyStore.getKeyStoreClient('key')).beginDeleteKey(name);
+    }
+  });
+
+  it('should generate a key with options - keyreference', async () => {
+    const name = 'ECDSA-sign-EC-' + random(16);
+    const cache = new KeyStoreInMemory();
+    const credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+    const keyStore = new KeyStoreKeyVault(credential, vaultUri, cache);
+    const plugin = new KeyVaultEcdsaProvider(subtle, keyStore);
+    try {
+      let keyReference = new KeyReference(name, 'key');
+      let curve = 'P-256K';
+      let options: IKeyGenerationOptions = { keyReference, curve }; 
+      const result: CryptoKeyPair = await plugin.onGenerateKey(alg, false, ['sign'], options);
+      expect((<any>result.publicKey).algorithm.namedCurve).toEqual('K-256');
+      expect(result.publicKey.algorithm.name).toEqual('ECDSA');
+      expect((<any>result.publicKey.algorithm).kid.startsWith('https')).toBeTruthy();
+      expect((<any>result.publicKey.algorithm).kid.includes(name)).toBeTruthy();
+    } finally {
+      await (<KeyClient>keyStore.getKeyStoreClient('key')).beginDeleteKey(name);
+    }
+  });
+
+  it('should generate a key with options - remoteKeyreference', async () => {
+    const name = 'ECDSA-sign-EC-' + random(16);
+    const remoteName = 'ECDSA-sign-EC-' + random(16) + '-remote';
+    const cache = new KeyStoreInMemory();
+    const credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+    const keyStore = new KeyStoreKeyVault(credential, vaultUri, cache);
+    const plugin = new KeyVaultEcdsaProvider(subtle, keyStore);
+    try {
+
+      let keyReference = new KeyReference(name, 'key', remoteName);
+      let curve = 'P-256K';
+      let options: IKeyGenerationOptions = { keyReference, curve }; 
+      const result: CryptoKeyPair = await plugin.onGenerateKey(alg, false, ['sign'], options);
+      expect((<any>result.publicKey).algorithm.namedCurve).toEqual('K-256');
+      expect(result.publicKey.algorithm.name).toEqual('ECDSA');
+      expect((<any>result.publicKey.algorithm).kid.startsWith('https')).toBeTruthy();
+      expect((<any>result.publicKey.algorithm).kid.includes(remoteName)).toBeTruthy();
+    } finally {
+      await (<KeyClient>keyStore.getKeyStoreClient('key')).beginDeleteKey(remoteName);
     }
   });
 

--- a/libs/plugin/package.json
+++ b/libs/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-plugin",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "description": "Package for plugeable crypto based on subtle crypto.",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
     "typescript": "3.9.2"
   },
   "dependencies": {
-    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.5",
     "@peculiar/webcrypto": "1.1.1",
     "@types/node": "12.12.16",
     "base64url": "^3.0.1",

--- a/libs/protocol-jose/package.json
+++ b/libs/protocol-jose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-protocol-jose",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript.git"
@@ -39,11 +39,11 @@
     "typescript": "3.9.2"
   },
   "dependencies": {
-    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-protocols-common": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-cryptofactory-suites": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-protocols-common": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-cryptofactory-suites": "1.1.11-preview.5",
     "base64url": "^3.0.1",
     "typescript-map": "0.0.7",
     "webcrypto-core": "1.1.1"

--- a/libs/protocols-common/package.json
+++ b/libs/protocols-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript-protocols-common",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript.git"
@@ -39,9 +39,9 @@
     "typescript": "3.9.2"
   },
   "dependencies": {
-    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.5",
     "base64url": "3.0.1",
     "typescript-map": "0.0.7",
     "webcrypto-core": "1.1.1"

--- a/libs/sdk/lib/Jose.ts
+++ b/libs/sdk/lib/Jose.ts
@@ -68,8 +68,8 @@ export default class Jose implements IPayloadProtectionSigning {
     if (this.builder.isLinkedDataProofsProtocol()) {
       // Support json ld proofs
       console.log('Support JSON LD proofs');
-      if (typeof payload !== 'object') {
-        payload = JSON.parse(payload);
+      if (typeof payload === 'string' || payload instanceof Buffer) {
+        return Promise.reject(`Input to sign JSON LD must be an object`);
       }
 
       let suite: IJsonLinkedDataProofSuite;
@@ -82,14 +82,12 @@ export default class Jose implements IPayloadProtectionSigning {
       this._jsonLdProof = await suite.sign(payload);
       console.log(`JSON LD Proof: ${this._jsonLdProof}`);
       return this;
-
-    } else if (typeof payload === 'string') {
-      payload = JSON.parse(payload);
-    } else if (payload instanceof Buffer) {
-      payload = JSON.parse(payload.toString())
-    }
+    } 
 
     if (this.isJwtProtocol()) {
+      if (typeof payload === 'string' || payload instanceof Buffer) {
+        return Promise.reject(`Input to sign JWT must be an object`);
+      }
 
       // Add standardized properties
       const current = Math.trunc(Date.now() / 1000);
@@ -104,7 +102,6 @@ export default class Jose implements IPayloadProtectionSigning {
         (<any>payload).jti = this.builder.jwtProtocol!.jti || uuidv4();
       }
 
-
       // Override properties
       for (let key in this.builder.jwtProtocol) {
         if (key in ['nbf', 'exp', 'jti']) {
@@ -112,7 +109,6 @@ export default class Jose implements IPayloadProtectionSigning {
         }
         (<any>payload)[key] = (<any>payload)[key] || this.builder.jwtProtocol[key];
       }
-
     }
 
     payload = Buffer.from(JSON.stringify(payload));

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verifiablecredentials-crypto-sdk-typescript",
-  "version": "1.1.11-preview.4",
+  "version": "1.1.11-preview.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/VerifiableCredentials-Crypto-SDK-Typescript.git"
@@ -52,15 +52,15 @@
     "jsonld": "2.0.2",
     "typescript-map": "0.0.7",
     "uuid": "^8.3.1",
-    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-cryptofactory-suites": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-elliptic": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-factory": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-plugin-keyvault": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-protocol-jose": "1.1.11-preview.4",
-    "verifiablecredentials-crypto-sdk-typescript-protocols-common": "1.1.11-preview.4",
+    "verifiablecredentials-crypto-sdk-typescript-keys": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-keystore": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-cryptofactory-suites": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-elliptic": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-factory": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-plugin-keyvault": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-protocol-jose": "1.1.11-preview.5",
+    "verifiablecredentials-crypto-sdk-typescript-protocols-common": "1.1.11-preview.5",
     "webcrypto-core": "1.1.1"
   },
   "nyc": {

--- a/libs/sdk/tests/Jose.spec.ts
+++ b/libs/sdk/tests/Jose.spec.ts
@@ -139,7 +139,7 @@ describe('Jose', () => {
     });
 
 
-    it('should sign and verify with JWT protocol', async () => {
+    fit('should sign and verify with JWT protocol', async () => {
         const payload = {
             firstName: 'Jules',
             lastName: 'Winnfield'
@@ -154,20 +154,34 @@ describe('Jose', () => {
             .useJwtProtocol({ someProp: 1 })
             .build();
 
-        jose = await jose.sign(payload);
+            jose = await jose.sign(payload);
 
-        // Check kid
-        let serialized = await jose.serialize();
-        jose = await jose.deserialize(serialized);
-        expect(jose.signatureProtectedHeader['typ']).toEqual('JWT');
-        expect(jose.signatureProtectedHeader.alg).toEqual('ES256K');
-        expect(jose.signatureProtectedHeader.kid).toEqual('did#neo');
-        const signedPayload: any = JSON.parse(jose.signaturePayload!.toString('utf-8'));
-        expect(signedPayload.someProp).toEqual(1); 
-        expect(signedPayload.jti).toBeDefined(); 
-        expect(signedPayload.exp).toBeDefined(); 
-        expect(signedPayload.nbf).toBeDefined(); 
-    });
+            // Check kid
+            let serialized = await jose.serialize();
+            jose = await jose.deserialize(serialized);
+            expect(jose.signatureProtectedHeader['typ']).toEqual('JWT');
+            expect(jose.signatureProtectedHeader.alg).toEqual('ES256K');
+            expect(jose.signatureProtectedHeader.kid).toEqual('did#neo');
+            let signedPayload: any = JSON.parse(jose.signaturePayload!.toString('utf-8'));
+            expect(signedPayload.someProp).toEqual(1); 
+            expect(signedPayload.jti).toBeDefined(); 
+            expect(signedPayload.exp).toBeDefined(); 
+            expect(signedPayload.nbf).toBeDefined(); 
+
+            jose = await jose.sign(Buffer.from(JSON.stringify(payload)));
+
+            // Check kid
+            serialized = await jose.serialize();
+            jose = await jose.deserialize(serialized);
+            expect(jose.signatureProtectedHeader['typ']).toEqual('JWT');
+            expect(jose.signatureProtectedHeader.alg).toEqual('ES256K');
+            expect(jose.signatureProtectedHeader.kid).toEqual('did#neo');
+            signedPayload = JSON.parse(jose.signaturePayload!.toString('utf-8'));
+            expect(signedPayload.someProp).toEqual(1); 
+            expect(signedPayload.jti).toBeDefined(); 
+            expect(signedPayload.exp).toBeDefined(); 
+            expect(signedPayload.nbf).toBeDefined(); 
+            });
 
     it('should check ProtectionFormat', () => {
         expect(Jose.getProtectionFormat('jwsflatjson')).toEqual(ProtectionFormat.JwsFlatJson);

--- a/libs/sdk/tests/LongFormDid.spec.ts
+++ b/libs/sdk/tests/LongFormDid.spec.ts
@@ -14,6 +14,9 @@ describe('LongFormDid', () => {
         crypto = await crypto.generateKey(KeyUse.Signature);
         crypto = await crypto.generateKey(KeyUse.Signature, 'recovery');
 
+        const jwk = await crypto.builder.keyStore.get(crypto.builder.signingKeyReference);
+        console.log(JSON.stringify(jwk));
+
         let did = await new LongFormDid(crypto).serialize();
         expect(did.startsWith('did:ion')).toBeTruthy();
         console.log(did);


### PR DESCRIPTION
Add remote reference to KeyReference.
Jose serialize and deserialized are now async.
Signing defaults to object argument instead of Buffer.